### PR TITLE
Implement ssh key retrieval API endpoint

### DIFF
--- a/api.go
+++ b/api.go
@@ -80,6 +80,24 @@ func ipxeBootScriptServer(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
+func sshKeyServer(w http.ResponseWriter, r *http.Request) {
+	v := r.URL.Query()
+	keyName := v.Get("name")
+	if keyName != "" {
+		log.Printf("retrieving ssh key %s.pub for %s", keyName, r.RemoteAddr)
+		sshKeyPath := filepath.Join(config.DataDir, fmt.Sprintf("sshkeys/%s.pub", keyName))
+		sshKey, err := sshKeyFromFile(sshKeyPath)
+		if err != nil {
+			log.Printf("Error reading ssh publickey from %s: %s", sshKeyPath, err)
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		data := []byte(fmt.Sprintf("[{\"key\": \"%s\"}]", sshKey))
+		w.Write(data)
+	}
+	return
+}
+
 func sshKeyFromFile(filename string) (string, error) {
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@ GET http://coreos.ipxe.example.com
 
 **Parameters**
 
-Name | Type | Description 
+Name | Type | Description
 -----|------|------------
 profile | string | The CoreOS iPXE profile to use.
 
@@ -33,4 +33,36 @@ set base-url http://coreos.ipxe.example.com/images/amd64-usr/${coreos-version}
 kernel ${base-url}/coreos_production_pxe.vmlinuz console=tty0 rootfstype=btrfs cloud-config-url=http://coreos.ipxe.example.com/configs/development.yml
 initrd ${base-url}/coreos_production_pxe_image.cpio.gz
 boot
+```
+
+## Retrieve an SSH Public Key
+
+Produce an SSH public key suitable for use by `coreos-cloudconfig` to insert into
+a user's `authorized_keys`.
+
+```
+GET http://coreos.ipxe.example.com/keys
+```
+
+**Parameters**
+
+Name | Type | Description
+-----|------|------------
+name | string | The name of the key (not including .pub)
+
+
+#### Generate a key for a specified name
+
+```
+GET http://coreos.ipxe.example.com/keys?name=foo
+```
+
+**Response**
+
+```
+HTTP/1.1 200 OK
+```
+
+```
+[{"key":"ssh-rsa AAAAB3N... foo@bar"}]
 ```

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ func main() {
 		http.Handle(s, http.StripPrefix(s,
 			http.FileServer(http.Dir(filepath.Join(config.DataDir, s)))))
 	}
+	// Register the sshkey script server.
+	http.HandleFunc("/keys", sshKeyServer)
 	// Register the iPXE boot script server.
 	http.HandleFunc("/", ipxeBootScriptServer)
 	// Start the iPXE Boot Server.


### PR DESCRIPTION
This PR implements an ssh pubkey endpoint which returns a json string in the format that [CoreOS's cloud-config](https://coreos.com/docs/cluster-management/setup/cloudinit-cloud-config/#toc_17) wants it so that you can easily insert the pubkey for users specified in `cloud-config`.
