### PR TITLE
find profiles by mac, asset tag, or system ID

### DIFF
--- a/api.go
+++ b/api.go
@@ -45,7 +45,7 @@ func ipxeBootScriptServer(w http.ResponseWriter, r *http.Request) {
 	asset := replacer.Replace(v.Get("asset"))
 	serial := replacer.Replace(v.Get("serial"))
 
-	for _, s := range []string{profile, mac, asset, serial} {
+	for _, s := range []string{profile, mac, asset, serial, "default"} {
 		if s != "" {
 			profilePath := filepath.Join(config.DataDir, fmt.Sprintf("profiles/%s.json", s))
 			log.Println("loading profile:", profilePath)
@@ -58,6 +58,7 @@ func ipxeBootScriptServer(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, err.Error(), 500)
 				return
 			}
+			break
 		}
 	}
 

--- a/api_test.go
+++ b/api_test.go
@@ -56,16 +56,16 @@ func createTestData(profiles map[string]*kernel.Options, sshKeys map[string]stri
 }
 
 var profileAOut = `#!ipxe
-set coreos-version 310.1.0
-set base-url http://example.com/images/amd64-usr/${coreos-version}
+set coreos-release-channel alpha
+set base-url http://example.com/images/${coreos-release-channel}
 kernel ${base-url}/coreos_production_pxe.vmlinuz
 initrd ${base-url}/coreos_production_pxe_image.cpio.gz
 boot
 `
 
 var profileBOut = `#!ipxe
-set coreos-version 310.1.0
-set base-url http://example.com/images/amd64-usr/${coreos-version}
+set coreos-release-channel stable
+set base-url http://example.com/images/${coreos-release-channel}
 kernel ${base-url}/coreos_production_pxe.vmlinuz rootfstype=btrfs console=tty0 console=ttyS0 cloud-config-url=http://example.com/configs/b.yml coreos.autologin=ttyS0 sshkey="ssh-rsa AAAAB3Ncoreos" root=/dev/sda1
 initrd ${base-url}/coreos_production_pxe_image.cpio.gz
 boot
@@ -97,7 +97,7 @@ func TestIPxeBootScriptServer(t *testing.T) {
 			Root:            "",
 			RootFstype:      "",
 			SSHKey:          "",
-			Version:         "310.1.0",
+			ReleaseChannel:  "alpha",
 		},
 		"b": &kernel.Options{
 			CloudConfig:     "b",
@@ -106,7 +106,7 @@ func TestIPxeBootScriptServer(t *testing.T) {
 			Root:            "/dev/sda1",
 			RootFstype:      "btrfs",
 			SSHKey:          "coreos",
-			Version:         "310.1.0",
+			ReleaseChannel:  "stable",
 		},
 		"c": &kernel.Options{
 			CloudConfig:     "c",
@@ -115,7 +115,7 @@ func TestIPxeBootScriptServer(t *testing.T) {
 			Root:            "/dev/sda1",
 			RootFstype:      "btrfs",
 			SSHKey:          "imabadkey",
-			Version:         "310.1.0",
+			ReleaseChannel:  "stable",
 		},
 	}
 

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"encoding/gob"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/kelseyhightower/coreos-ipxe-server/machine"
+)
+
+var machineUsageString = `Usage: %s machines <action>
+
+actions:
+  create   Create a new machine.
+  get      Get a machine.
+  list     List all machines.
+`
+
+func machineCmdHandler(args []string) error {
+	fs := flag.NewFlagSet("machine", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, machineUsageString, os.Args[0])
+	}
+	fs.Parse(args)
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "missing action\n")
+		fs.Usage()
+		os.Exit(1)
+	}
+	action := args[0]
+	switch action {
+	case "create":
+		return createMachine(args[1:])
+	case "get":
+		return getMachine(args[1:])
+	case "list":
+		return listMachines(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown action\n")
+		fs.Usage()
+		os.Exit(1)
+	}
+	return nil
+}
+
+func createMachine(arguments []string) error {
+	var (
+		name    string
+		mac     string
+		profile string
+	)
+	fs := flag.NewFlagSet("createMachine", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s machine create -mac <mac> [flags]\n", os.Args[0])
+		fs.PrintDefaults()
+	}
+	fs.StringVar(&name, "name", "", "machine name")
+	fs.StringVar(&mac, "mac", "", "machine mac address")
+	fs.StringVar(&profile, "profile", "default", "machine profile")
+
+	err := fs.Parse(arguments)
+	if err == flag.ErrHelp {
+		fs.Usage()
+		os.Exit(0)
+	}
+	if err != nil {
+		return err
+	}
+
+	if mac == "" {
+		fmt.Fprintf(os.Stderr, "A valid (non-empty) mac address is required. Use the -mac flag.\n")
+		os.Exit(1)
+	}
+
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+
+	m, err := machine.New(name, mac)
+	if err != nil {
+		return err
+	}
+	m.SetProfile(profile)
+
+	err = enc.Encode(m)
+	if err != nil {
+		return err
+	}
+
+	err = store.Save("machines", name, buf.Bytes())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func listMachines(args []string) error {
+	ms, err := store.List("machines")
+	if err != nil {
+		return err
+	}
+	fmt.Println("machines:\n")
+	for k := range ms {
+		fmt.Println(k)
+	}
+	return nil
+}
+
+func getMachine(args []string) error {
+	var (
+		name string
+	)
+	fs := flag.NewFlagSet("findMachine", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s machine find -name <name>\n", os.Args[0])
+		fs.PrintDefaults()
+	}
+	fs.StringVar(&name, "name", "", "machine name")
+
+	err := fs.Parse(args)
+	if err == flag.ErrHelp {
+		fs.Usage()
+		os.Exit(0)
+	}
+	if err != nil {
+		return err
+	}
+
+	if name == "" {
+		fmt.Fprintf(os.Stderr, "A valid (non-empty) name is required. Use the -name flag.\n")
+		os.Exit(1)
+	}
+
+	rawMachine, err := store.Get("machines", name)
+	if err != nil {
+		return err
+	}
+
+	dec := gob.NewDecoder(bytes.NewReader(rawMachine))
+	var node machine.Machine
+	if err := dec.Decode(&node); err != nil {
+		return err
+	}
+
+	fmt.Println(&node)
+
+	return nil
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/kelseyhightower/coreos-ipxe-server/store/backend/boltdb"
+)
+
+var (
+	store            *boltdb.Store
+	defaultStorePath = "/tmp/db"
+)
+
+// commands represent the list of available sub-commands.
+var commands = map[string]func([]string) error{
+	"machine": machineCmdHandler,
+	"profile": profileCmdHandler,
+}
+
+var usageString = `Usage: %s <machine | profile> [flags]
+
+commands:
+  machine    Manage machines.
+  profile    Manage iPXE profiles.
+`
+
+func main() {
+	var err error
+
+	fs := flag.NewFlagSet("main", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, usageString, os.Args[0])
+		os.Exit(0)
+	}
+	fs.Parse(os.Args[1:])
+
+	if len(os.Args) < 2 {
+		fs.Usage()
+	}
+
+	subcommand := os.Args[1]
+	args := os.Args[2:]
+
+	command, ok := commands[subcommand]
+	if !ok {
+		fmt.Printf("unknown command: %s\n", subcommand)
+		fs.Usage()
+	}
+
+	store, err = boltdb.New(defaultStorePath)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if err := command(args); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"encoding/gob"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/kelseyhightower/coreos-ipxe-server/profile"
+)
+
+var profileUsageString = `Usage: %s profile <action>
+
+actions:
+  create   Create a new profile.
+  get      Get a profile.
+  list     List all profiles.
+`
+
+func profileCmdHandler(args []string) error {
+	fs := flag.NewFlagSet("profile", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, profileUsageString, os.Args[0])
+	}
+	fs.Parse(args)
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "missing action\n")
+		fs.Usage()
+		os.Exit(1)
+	}
+	action := args[0]
+	switch action {
+	case "create":
+		return createProfile(args[1:])
+	case "list":
+		return listProfiles(args[1:])
+	case "get":
+		return getProfile(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown action\n")
+		fs.Usage()
+		os.Exit(1)
+	}
+	return nil
+}
+
+func createProfile(args []string) error {
+	var (
+		cloudConfig     string
+		console         string
+		coreOSAutologin string
+		name            string
+		releaseChannel  string
+		root            string
+		rootFstype      string
+		sshKey          string
+	)
+
+	fs := flag.NewFlagSet("createProfile", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s profile create -name <name> [flags]\n", os.Args[0])
+		fs.PrintDefaults()
+	}
+
+	fs.StringVar(&cloudConfig, "cloud-config", "default", "name of the cloud-config file")
+	fs.StringVar(&console, "console", "", "the consoles to enable kernel output and login prompt on")
+	fs.StringVar(&coreOSAutologin, "coreos-auto-login", "", "the consoles to enable shell without password")
+	fs.StringVar(&name, "name", "", "profile name")
+	fs.StringVar(&releaseChannel, "release-channel", "stable", "CoreOS release channel")
+	fs.StringVar(&root, "root", "", "local filesystem name")
+	fs.StringVar(&rootFstype, "root-fs-type", "", "file system type for the writable root filesystem")
+	fs.StringVar(&sshKey, "ssh-key", "", "the ssh key name for the core user")
+
+	err := fs.Parse(args)
+	if err == flag.ErrHelp {
+		fs.Usage()
+		os.Exit(0)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if name == "" {
+		fmt.Fprintf(os.Stderr, "A valid (non-empty) name is required. Use the -name flag.\n")
+		os.Exit(1)
+	}
+
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+
+	p := &profile.Profile{
+		CloudConfig:     cloudConfig,
+		Console:         []string{console},
+		CoreOSAutologin: coreOSAutologin,
+		Name:            name,
+		ReleaseChannel:  releaseChannel,
+		Root:            root,
+		RootFstype:      rootFstype,
+		SSHKey:          sshKey,
+	}
+
+	if err := enc.Encode(p); err != nil {
+		return err
+	}
+
+	if err := store.Save("profiles", name, buf.Bytes()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func listProfiles(args []string) error {
+	ps, err := store.List("profiles")
+	if err != nil {
+		return err
+	}
+	fmt.Println("profiles:\n")
+	for k := range ps {
+		fmt.Printf("  %s\n", k)
+	}
+	return nil
+}
+
+func getProfile(args []string) error {
+	var (
+		name string
+	)
+
+	fs := flag.NewFlagSet("getProfile", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s profile get -name <name> [flags]\n", os.Args[0])
+		fs.PrintDefaults()
+	}
+
+	fs.StringVar(&name, "name", "", "profile name")
+
+	err := fs.Parse(args)
+	if err == flag.ErrHelp {
+		fs.Usage()
+		os.Exit(0)
+	}
+	if err != nil {
+		return err
+	}
+
+	if name == "" {
+		fmt.Fprintf(os.Stderr, "A valid (non-empty) name is required. Use the -name flag.\n")
+		os.Exit(1)
+	}
+
+	rawProfile, err := store.Get("profiles", name)
+	if err != nil {
+		return err
+	}
+
+	dec := gob.NewDecoder(bytes.NewReader(rawProfile))
+	var p profile.Profile
+	if err := dec.Decode(&p); err != nil {
+		return err
+	}
+
+	fmt.Println(&p)
+
+	return nil
+}

--- a/kernel/options.go
+++ b/kernel/options.go
@@ -12,7 +12,7 @@ type Options struct {
 	Root            string   `json:"root"`
 	RootFstype      string   `json:"rootfstype"`
 	SSHKey          string   `json:"sshkey"`
-	Version         string   `json:"version"`
+	ReleaseChannel  string   `json:"release_channel"`
 	cloudConfigUrl  string
 }
 

--- a/kernel/options.go
+++ b/kernel/options.go
@@ -9,10 +9,10 @@ type Options struct {
 	CloudConfig     string   `json:"cloud_config"`
 	Console         []string `json:"console"`
 	CoreOSAutologin string   `json:"coreos_autologin"`
+	ReleaseChannel  string   `json:"release_channel"`
 	Root            string   `json:"root"`
 	RootFstype      string   `json:"rootfstype"`
 	SSHKey          string   `json:"sshkey"`
-	ReleaseChannel  string   `json:"release_channel"`
 	cloudConfigUrl  string
 }
 

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -1,0 +1,48 @@
+package machine
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"text/template"
+)
+
+type Machine struct {
+	Name         string
+	HardwareAddr net.HardwareAddr
+	Profile      string
+}
+
+type Data map[string]string
+
+func New(name string, mac string) (*Machine, error) {
+	macAddr, err := net.ParseMAC(mac)
+	if err != nil {
+		return nil, err
+	}
+	m := &Machine{
+		Name:         name,
+		HardwareAddr: macAddr,
+	}
+	return m, nil
+}
+
+func (m *Machine) SetProfile(name string) error {
+	m.Profile = name
+	return nil
+}
+
+var outputTemplate = template.Must(template.New("machine").Parse(`
+name        : {{.Name}}
+mac-address : {{.HardwareAddr}}
+profile     : {{.Profile}}
+`))
+
+func (m *Machine) String() string {
+	var buf bytes.Buffer
+	err := outputTemplate.Execute(&buf, m)
+	if err != nil {
+		fmt.Println("Error generating profile output:", err)
+	}
+	return buf.String()
+}

--- a/main.go
+++ b/main.go
@@ -19,16 +19,21 @@ func main() {
 		http.Handle(s, http.StripPrefix(s,
 			http.FileServer(http.Dir(filepath.Join(config.DataDir, s)))))
 	}
+
 	// Register the sshkey script server.
 	http.HandleFunc("/keys", sshKeyServer)
+
 	// Register the iPXE boot script server.
 	http.HandleFunc("/", ipxeBootScriptServer)
+
 	// Start the iPXE Boot Server.
 	fmt.Println("Starting CoreOS iPXE Server...")
 	fmt.Printf("Listening on %s\n", config.ListenAddr)
+
 	if config.BaseUrl != "" {
 		fmt.Printf("Advertised URL %s\n", config.BaseUrl)
 	}
 	fmt.Printf("Data directory: %s\n", config.DataDir)
+
 	log.Fatal(http.ListenAndServe(config.ListenAddr, nil))
 }

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -1,0 +1,39 @@
+package profile
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+// Profile represents and CoreOS iPXE profile.
+type Profile struct {
+	CloudConfig     string
+	Console         []string
+	CoreOSAutologin string
+	Name            string
+	ReleaseChannel  string
+	Root            string
+	RootFstype      string
+	SSHKey          string
+}
+
+var outputTemplate = template.Must(template.New("profile").Parse(`
+name             : {{.Name}}
+cloud-config     : {{.CloudConfig}}
+console          : {{.Console}}
+coreos-autologin : {{.CoreOSAutologin}}
+release-channel  : {{.ReleaseChannel}}
+root             : {{.Root}}
+root-fstype      : {{.RootFstype}}
+ssh-key          : {{.SSHKey}}
+`))
+
+func (p *Profile) String() string {
+	var buf bytes.Buffer
+	err := outputTemplate.Execute(&buf, p)
+	if err != nil {
+		fmt.Println("Error generating profile output:", err)
+	}
+	return buf.String()
+}

--- a/store/backend/boltdb/store.go
+++ b/store/backend/boltdb/store.go
@@ -1,0 +1,71 @@
+package boltdb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/boltdb/bolt"
+)
+
+var buckets = []string{"machines", "profiles"}
+
+type Store struct {
+	db *bolt.DB
+}
+
+func New(path string) (*Store, error) {
+	dbOptions := bolt.Options{
+		Timeout: time.Duration(time.Second * 10),
+	}
+	db, err := bolt.Open(path, 0644, &dbOptions)
+	if err != nil {
+		return nil, err
+	}
+	for _, bucket := range buckets {
+		err := db.Update(func(tx *bolt.Tx) error {
+			_, err := tx.CreateBucket([]byte(bucket))
+			if err != nil {
+				fmt.Errorf("create bucket: %s", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Store{db: db}, nil
+}
+
+func (s *Store) Get(bucket, id string) ([]byte, error) {
+	var result []byte
+	err := s.db.View(func(tx *bolt.Tx) error {
+		result = tx.Bucket([]byte(bucket)).Get([]byte(id))
+		return nil
+	})
+	return result, err
+}
+
+func (s *Store) Save(bucket, id string, value []byte) error {
+	s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucket))
+		err := b.Put([]byte(id), value)
+		return err
+	})
+	return nil
+}
+
+func (s *Store) List(bucket string) (map[string][]byte, error) {
+	m := make(map[string][]byte)
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(bucket))
+		c := b.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			m[string(k)] = v
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}


### PR DESCRIPTION
This change allows the iPXE server to locate profiles based on mac addresses, asset tags, and system IDs.

```
curl http://192.168.12.1:4777?mac=${net0/mac}&serial=${serial}&asset=${asset}
```

```
2015/01/23 01:39:37 creating boot script for 192.168.12.149:19485
2015/01/23 01:39:37 /?mac=00:0c:29:6b:bb:94&serial=VMware-56 4d 47 08 5d 35 1f 22-6e 4b f8 f3 b0 6b bb 94&asset=No Asset Tag <nil>
2015/01/23 01:39:37 loading profile: /opt/coreos-ipxe-server/profiles/00-0c-29-6b-bb-94.json
2015/01/23 01:39:37 loading profile: /opt/coreos-ipxe-server/profiles/No-Asset-Tag.json
2015/01/23 01:39:37 loading profile: /opt/coreos-ipxe-server/profiles/VMware-56-4d-47-08-5d-35-1f-22-6e-4b-f8-f3-b0-6b-bb-94.json
```
