### PR TITLE
fixed relative links in README by adding a space

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ The CoreOS iPXE Server attempts to automate as much of the [Booting CoreOS via i
 ## Table of Contents
 
 - [Installation](#installation)
-- [Getting Started](docs/getting_started.md)
-- [API](docs/api.md)
-- [Profiles](docs/profiles.md)
-- [Docker setup example](docs/docker.md)
+- [Getting Started] (docs/getting_started.md)
+- [API] (docs/api.md)
+- [Profiles] (docs/profiles.md)
+- [Docker setup example] (docs/docker.md)
 
 ## Installation
 


### PR DESCRIPTION
A small thing, but the Github format for relative links in subfolders seems to have broken.  Adding a space between the text and the link fixed it.  I didn't remove the broken build link from drone.io, but that may be something worth fixing/removing. 
